### PR TITLE
Fix multi-window / multi-editor Markwell routing

### DIFF
--- a/src/MarkdownEditorProvider.ts
+++ b/src/MarkdownEditorProvider.ts
@@ -48,9 +48,53 @@ type WebviewMessage =
   | { type: 'blur' };
 
 let activePanel: vscode.WebviewPanel | null = null;
-const documentPanels = new Map<string, vscode.WebviewPanel>();
+/** All Markwell webviews per document URI (multiple VS Code windows can each host one). */
+const documentPanels = new Map<string, vscode.WebviewPanel[]>();
+const lastFocusedPanelByUri = new Map<string, vscode.WebviewPanel>();
 let pendingSaveResolvers = new Map<string, (markdown: string) => void>();
 const expectedDocumentEdits = new Map<string, string>();
+
+function addDocumentPanel(uri: string, panel: vscode.WebviewPanel) {
+  const list = documentPanels.get(uri) ?? [];
+  list.push(panel);
+  documentPanels.set(uri, list);
+}
+
+function removeDocumentPanel(uri: string, panel: vscode.WebviewPanel) {
+  const list = documentPanels.get(uri);
+  if (!list) return;
+  const i = list.indexOf(panel);
+  if (i < 0) return;
+  list.splice(i, 1);
+  if (list.length === 0) {
+    documentPanels.delete(uri);
+    if (lastFocusedPanelByUri.get(uri) === panel) lastFocusedPanelByUri.delete(uri);
+    return;
+  }
+  if (lastFocusedPanelByUri.get(uri) === panel) {
+    lastFocusedPanelByUri.set(uri, list[list.length - 1]!);
+  }
+}
+
+function pickPanelForDocument(document: vscode.TextDocument): vscode.WebviewPanel | undefined {
+  const uri = document.uri.toString();
+  const panels = documentPanels.get(uri);
+  if (!panels?.length) return undefined;
+
+  const ae = vscode.window.activeTextEditor;
+  if (ae && ae.document.uri.toString() === uri) {
+    const col = ae.viewColumn;
+    if (col !== undefined) {
+      const byCol = panels.find((p) => p.viewColumn === col);
+      if (byCol) return byCol;
+    }
+  }
+
+  const last = lastFocusedPanelByUri.get(uri);
+  if (last && panels.includes(last)) return last;
+
+  return panels[panels.length - 1];
+}
 
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   private readonly selfEdits = new WeakMap<vscode.TextDocument, string>();
@@ -58,6 +102,14 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
   constructor(private readonly context: vscode.ExtensionContext) { }
 
   static postToActivePanel(message: unknown): boolean {
+    const ae = vscode.window.activeTextEditor;
+    if (ae?.document.languageId === 'markdown') {
+      const panel = pickPanelForDocument(ae.document);
+      if (panel) {
+        panel.webview.postMessage(message);
+        return true;
+      }
+    }
     if (activePanel) {
       activePanel.webview.postMessage(message);
       return true;
@@ -67,7 +119,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
 
   static requestContentBeforeSave(document: vscode.TextDocument): Promise<string | null> {
     const uri = document.uri.toString();
-    const panel = documentPanels.get(uri);
+    const panel = pickPanelForDocument(document);
     if (!panel) return Promise.resolve(null);
     return new Promise<string | null>((resolve) => {
       const timeout = setTimeout(() => {
@@ -102,7 +154,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     };
 
     webviewPanel.webview.html = this.buildHtml(webviewPanel.webview);
-    documentPanels.set(document.uri.toString(), webviewPanel);
+    addDocumentPanel(document.uri.toString(), webviewPanel);
 
     const applyEditImmediate = async (markdown: string) => {
       markdown = ensureTrailingEof(markdown);
@@ -159,6 +211,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
           break;
         case 'focus':
           activePanel = webviewPanel;
+          lastFocusedPanelByUri.set(document.uri.toString(), webviewPanel);
           vscode.commands.executeCommand('setContext', 'markwellEditorFocused', true);
           break;
         case 'blur':
@@ -184,6 +237,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.onDidChangeViewState(() => {
       if (webviewPanel.active) {
         activePanel = webviewPanel;
+        lastFocusedPanelByUri.set(document.uri.toString(), webviewPanel);
         vscode.commands.executeCommand('setContext', 'markwellEditorFocused', true);
       } else if (activePanel === webviewPanel) {
         activePanel = null;
@@ -223,7 +277,7 @@ export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.onDidDispose(() => {
       pendingSaveResolvers.delete(document.uri.toString());
       expectedDocumentEdits.delete(document.uri.toString());
-      documentPanels.delete(document.uri.toString());
+      removeDocumentPanel(document.uri.toString(), webviewPanel);
       if (activePanel === webviewPanel) {
         activePanel = null;
         vscode.commands.executeCommand('setContext', 'markwellEditorFocused', false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The extension kept module-level state assuming at most one webview per file URI:

1. **`documentPanels`** was `Map<uri, panel>`. Opening the same markdown (or another window’s instance) **replaced** the previous entry, so save sync and other routing targeted the wrong webview or none.
2. **`postToActivePanel`** always posted to a single global `activePanel`, so with multiple windows the “active” panel could be the wrong one after focus/view-state changes.

## Fix
- Store **all** webviews per URI in an array.
- **`pickPanelForDocument`**: prefer the panel whose `viewColumn` matches `vscode.window.activeTextEditor` when the document matches, else the last-focused panel for that URI, else the last registered panel.
- **`postToActivePanel`**: use `activeTextEditor` + `pickPanelForDocument` first, then fall back to `activePanel` (webview focus when `activeTextEditor` is unset).

## Testing
- `npm run compile` (local)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6007bdbd-a99e-49b0-8887-3a71d7113772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6007bdbd-a99e-49b0-8887-3a71d7113772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

