### PR TITLE
Make tables more compact (Notion-style)

### DIFF
--- a/webview-src/styles.css
+++ b/webview-src/styles.css
@@ -418,18 +418,18 @@ body:hover #topbar,
   margin: 0;
 }
 
-/* ---- Tables (Notion-accurate) ---- */
+/* ---- Tables (Notion-compact) ---- */
 .mmw-prose .tableWrapper {
   overflow-x: auto;
-  margin: 14px 0;
+  margin: 8px 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 4px;
 }
 
 .mmw-prose table {
   border-collapse: collapse;
   width: 100%;
-  font-size: 0.92em;
+  font-size: 0.88em;
 }
 
 .mmw-prose th,
@@ -437,10 +437,10 @@ body:hover #topbar,
   border: none;
   border-bottom: 1px solid var(--border);
   border-right: 1px solid var(--border);
-  padding: 9px 14px;
+  padding: 5px 10px;
   text-align: left;
   vertical-align: top;
-  min-width: 100px;
+  min-width: 60px;
 }
 
 .mmw-prose th:last-child,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reduces table visual size to match Notion’s compact style:

- **Cell padding**: 9px 14px → 5px 10px
- **Table wrapper margin**: 14px → 8px  
- **Min column width**: 100px → 60px
- **Table font**: 0.92em → 0.88em
- **Border radius**: 6px → 4px

Closes #79 (or related notion-table-style issue).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99dbc766-0378-4c79-b87f-a7f9e74a6bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99dbc766-0378-4c79-b87f-a7f9e74a6bde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

