### PR TITLE
Notion-style table controls: add/delete columns and rows, sort, reorder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "markwell",
       "version": "0.2.3",
+      "license": "MIT",
       "dependencies": {
         "@tiptap/core": "^2.2.0",
         "@tiptap/extension-color": "^2.27.2",

--- a/webview-src/editor.ts
+++ b/webview-src/editor.ts
@@ -45,7 +45,7 @@ export function createEditor(
       HeadingWithIds.configure({ levels: [1, 2, 3] }),
 
       // Tables
-      Table.configure({ resizable: false }),
+      Table.configure({ resizable: false, renderWrapper: true }),
       TableRow,
       TableHeader,
       TableCell,

--- a/webview-src/main.ts
+++ b/webview-src/main.ts
@@ -1,6 +1,7 @@
 import { createEditor } from './editor';
 import { buildPmToMarkdownMap, pmPosToMdOffset } from './selection-sync';
 import { initDragHandles } from './drag-handle';
+import { initTableHoverUI } from './table-hover-ui';
 import { initFormatToolbar } from './format-toolbar';
 import { addImagePasteHandler, initImageToolbar } from './image-extension';
 import { initToc } from './toc';
@@ -231,6 +232,7 @@ editor.on('update', updateWordCount);
 
 // ---- Init sub-systems ----
 initDragHandles(editor);
+initTableHoverUI(editor);
 initFormatToolbar(editor, post);
 addImagePasteHandler(editor);
 initImageToolbar(editor);

--- a/webview-src/styles.css
+++ b/webview-src/styles.css
@@ -466,6 +466,86 @@ body:hover #topbar,
   background: var(--sel);
 }
 
+/* ---- Notion-style table controls ---- */
+.table-ctrl-btn {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--text-2);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  transition: background 0.1s, color 0.1s;
+}
+.table-ctrl-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}
+.table-ctrl-delete:hover {
+  background: rgba(220, 38, 38, 0.15);
+  color: #dc2626;
+}
+
+.table-ctrl-floating {
+  position: fixed;
+  z-index: 250;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+.table-ctrl-floating.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.table-header-menu {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background: var(--bg);
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  z-index: 250;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+.table-header-menu.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.table-col-drag {
+  position: fixed;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  color: var(--handle);
+  cursor: grab;
+  z-index: 250;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.1s;
+}
+.table-col-drag.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.table-col-drag:active {
+  cursor: grabbing;
+}
+
 /* ---- Floating format toolbar ---- */
 #format-toolbar {
   position: fixed;
@@ -1264,7 +1344,10 @@ body.vscode-dark .mmw-prose a.mmw-link {
   #toc-panel,
   #img-toolbar,
   #link-popover,
-  #color-pop {
+  #color-pop,
+  .table-ctrl-floating,
+  .table-header-menu,
+  .table-col-drag {
     display: none !important;
   }
 

--- a/webview-src/table-hover-ui.ts
+++ b/webview-src/table-hover-ui.ts
@@ -9,10 +9,17 @@ import type { Node as ProseNode } from '@tiptap/pm/model';
 const EDGE_ZONE = 24;
 const HEADER_CONTROL_OFFSET = 4;
 
-function findTableWrapper(el: Node | null): HTMLElement | null {
-  while (el) {
-    if (el instanceof HTMLElement && el.classList?.contains('tableWrapper')) return el;
-    el = el.parentElement;
+function findTableContainer(el: Node | null): { container: HTMLElement; table: HTMLTableElement } | null {
+  let node: Node | null = el;
+  while (node) {
+    if (node instanceof HTMLTableElement) {
+      return { container: node, table: node };
+    }
+    if (node instanceof HTMLElement && node.classList?.contains('tableWrapper')) {
+      const table = node.querySelector('table');
+      return table ? { container: node, table } : null;
+    }
+    node = node.parentElement;
   }
   return null;
 }
@@ -151,7 +158,7 @@ export function initTableHoverUI(editor: Editor) {
   document.body.appendChild(rowDeleteBtn);
   document.body.appendChild(colDragHandle);
 
-  let activeWrapper: HTMLElement | null = null;
+  let activeContainer: HTMLElement | null = null;
   let activeTable: HTMLTableElement | null = null;
   let activeHeaderCell: HTMLTableCellElement | null = null;
   let activeRow: HTMLTableRowElement | null = null;
@@ -166,7 +173,7 @@ export function initTableHoverUI(editor: Editor) {
     headerMenu.classList.remove('visible');
     rowDeleteBtn.classList.remove('visible');
     colDragHandle.classList.remove('visible');
-    activeWrapper = null;
+    activeContainer = null;
     activeTable = null;
     activeHeaderCell = null;
     activeRow = null;
@@ -176,7 +183,7 @@ export function initTableHoverUI(editor: Editor) {
   function isOverTableOrControls(el: Element | null): boolean {
     if (!el) return false;
     if (ctrlElements.some((c) => c.contains(el))) return true;
-    return proseEl.contains(el) && !!findTableWrapper(el as Node);
+    return proseEl.contains(el) && !!findTableContainer(el as Node);
   }
 
   document.addEventListener('mousemove', (e: MouseEvent) => {
@@ -188,14 +195,13 @@ export function initTableHoverUI(editor: Editor) {
     }
     if (ctrlElements.some((c) => c.contains(elAt))) return;
 
-    const wrapper = findTableWrapper(e.target as Node);
-    const tableEl = wrapper?.querySelector('table') ?? null;
-    if (!wrapper || !tableEl) {
+    const found = findTableContainer(e.target as Node);
+    if (!found) {
       hideAll();
       return;
     }
-
-    const rect = wrapper.getBoundingClientRect();
+    const { container, table: tableEl } = found;
+    const rect = container.getBoundingClientRect();
     const relX = e.clientX - rect.left;
     const relY = e.clientY - rect.top;
     const nearRight = relX >= rect.width - EDGE_ZONE;
@@ -207,7 +213,7 @@ export function initTableHoverUI(editor: Editor) {
     const bodyRow = row && !isHeaderRow(row) ? row : null;
 
     if (nearRight && tableEl) {
-      activeWrapper = wrapper;
+      activeContainer = container;
       activeTable = tableEl;
       addColBtn.classList.add('visible');
       addColBtn.style.left = `${rect.right - 32}px`;
@@ -220,7 +226,7 @@ export function initTableHoverUI(editor: Editor) {
     }
 
     if (nearBottom && tableEl) {
-      activeWrapper = wrapper;
+      activeContainer = container;
       activeTable = tableEl;
       addRowBtn.classList.add('visible');
       addRowBtn.style.left = `${rect.left + rect.width / 2 - 14}px`;
@@ -233,7 +239,7 @@ export function initTableHoverUI(editor: Editor) {
     }
 
     if (headerCell) {
-      activeWrapper = wrapper;
+      activeContainer = container;
       activeTable = tableEl;
       activeHeaderCell = headerCell;
       const hr = headerCell.getBoundingClientRect();
@@ -251,7 +257,7 @@ export function initTableHoverUI(editor: Editor) {
     }
 
     if (bodyRow) {
-      activeWrapper = wrapper;
+      activeContainer = container;
       activeTable = tableEl;
       activeRow = bodyRow;
       const rowRect = bodyRow.getBoundingClientRect();

--- a/webview-src/table-hover-ui.ts
+++ b/webview-src/table-hover-ui.ts
@@ -1,0 +1,387 @@
+/**
+ * Notion-style table controls: add/delete column/row, sort, reorder columns.
+ * Hover zones and header controls wire to TipTap table commands.
+ */
+
+import { Editor } from '@tiptap/core';
+import type { Node as ProseNode } from '@tiptap/pm/model';
+
+const EDGE_ZONE = 24;
+const HEADER_CONTROL_OFFSET = 4;
+
+function findTableWrapper(el: Node | null): HTMLElement | null {
+  while (el) {
+    if (el instanceof HTMLElement && el.classList?.contains('tableWrapper')) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+function findTableEl(el: Node | null): HTMLTableElement | null {
+  while (el) {
+    if (el instanceof HTMLTableElement) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+function getCellPos(editor: Editor, cell: HTMLTableCellElement): number {
+  const pos = editor.view.posAtDOM(cell, 0);
+  const $pos = editor.state.doc.resolve(pos);
+  return $pos.pos + 1;
+}
+
+function getTableNode(editor: Editor, tableEl: HTMLTableElement): { pos: number; node: ProseNode } | null {
+  const cell = tableEl.querySelector('th, td');
+  if (!cell) return null;
+  const cellPos = getCellPos(editor, cell as HTMLTableCellElement);
+  const $pos = editor.state.doc.resolve(cellPos);
+  for (let d = $pos.depth; d > 0; d--) {
+    const node = $pos.node(d);
+    if (node.type.name === 'table') return { pos: $pos.before(d), node };
+  }
+  return null;
+}
+
+function columnIndex(cell: HTMLTableCellElement): number {
+  const row = cell.closest('tr');
+  if (!row) return 0;
+  const cells = Array.from(row.querySelectorAll('th, td'));
+  return cells.indexOf(cell);
+}
+
+function rowIndex(tr: HTMLTableRowElement): number {
+  const tbody = tr.closest('tbody, thead');
+  if (!tbody) return 0;
+  return Array.from(tbody.querySelectorAll('tr')).indexOf(tr);
+}
+
+function isHeaderRow(tr: HTMLTableRowElement): boolean {
+  return tr.closest('thead') !== null;
+}
+
+function sortTable(editor: Editor, tableEl: HTMLTableElement, colIndex: number, asc: boolean) {
+  const info = getTableNode(editor, tableEl);
+  if (!info) return;
+  const { pos, node } = info;
+  const rows: ProseNode[] = [];
+  node.forEach((row) => rows.push(row));
+  const headerRows: ProseNode[] = [];
+  const bodyRows: ProseNode[] = [];
+  rows.forEach((row) => {
+    const firstCell = row.firstChild;
+    if (firstCell?.type.name === 'table_header') headerRows.push(row);
+    else bodyRows.push(row);
+  });
+  if (bodyRows.length <= 1) return;
+
+  const getCellText = (row: ProseNode, i: number): string => {
+    const cell = row.child(i);
+    return cell ? cell.textContent.trim() : '';
+  };
+
+  bodyRows.sort((a, b) => {
+    const aVal = getCellText(a, colIndex);
+    const bVal = getCellText(b, colIndex);
+    const aNum = parseFloat(aVal.replace(/[^0-9.-]/g, ''));
+    const bNum = parseFloat(bVal.replace(/[^0-9.-]/g, ''));
+    const numCompare = !Number.isNaN(aNum) && !Number.isNaN(bNum);
+    const cmp = numCompare ? aNum - bNum : aVal.localeCompare(bVal);
+    return asc ? cmp : -cmp;
+  });
+
+  const newRows = [...headerRows, ...bodyRows];
+  const newTable = node.type.create(node.attrs, newRows);
+  const tr = editor.state.tr.replaceWith(pos, pos + node.nodeSize, newTable);
+  editor.view.dispatch(tr);
+  editor.view.focus();
+}
+
+function moveColumn(editor: Editor, tableEl: HTMLTableElement, fromCol: number, toCol: number) {
+  const info = getTableNode(editor, tableEl);
+  if (!info || fromCol === toCol) return;
+  const { pos, node } = info;
+  const schema = editor.state.schema;
+  const newRows: ProseNode[] = [];
+  node.forEach((row) => {
+    const cells: ProseNode[] = [];
+    row.forEach((cell) => cells.push(cell));
+    const [extracted] = cells.splice(fromCol, 1);
+    cells.splice(toCol, 0, extracted);
+    newRows.push(row.type.create(row.attrs, cells));
+  });
+  const newTable = node.type.create(node.attrs, newRows);
+  const tr = editor.state.tr.replaceWith(pos, pos + node.nodeSize, newTable);
+  editor.view.dispatch(tr);
+  editor.view.focus();
+}
+
+function createButton(icon: string, title: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.title = title;
+  btn.className = 'table-ctrl-btn';
+  btn.innerHTML = icon;
+  return btn;
+}
+
+export function initTableHoverUI(editor: Editor) {
+  const proseEl = editor.view.dom as HTMLElement;
+
+  const addColBtn = createButton('+', 'Add column');
+  addColBtn.classList.add('table-ctrl-floating');
+  const addRowBtn = createButton('+', 'Add row');
+  addRowBtn.classList.add('table-ctrl-floating');
+  const headerMenu = document.createElement('div');
+  headerMenu.className = 'table-header-menu';
+  headerMenu.innerHTML = `
+    <button type="button" class="table-ctrl-btn" title="Sort ascending">↑</button>
+    <button type="button" class="table-ctrl-btn" title="Sort descending">↓</button>
+    <button type="button" class="table-ctrl-btn table-ctrl-delete" title="Delete column">×</button>
+  `;
+  const rowDeleteBtn = createButton('×', 'Delete row');
+  rowDeleteBtn.className = 'table-ctrl-btn table-ctrl-delete table-ctrl-floating';
+
+  const colDragHandle = document.createElement('div');
+  colDragHandle.className = 'table-col-drag';
+  colDragHandle.title = 'Drag to reorder column';
+  colDragHandle.innerHTML = '⋮⋮';
+
+  document.body.appendChild(addColBtn);
+  document.body.appendChild(addRowBtn);
+  document.body.appendChild(headerMenu);
+  document.body.appendChild(rowDeleteBtn);
+  document.body.appendChild(colDragHandle);
+
+  let activeWrapper: HTMLElement | null = null;
+  let activeTable: HTMLTableElement | null = null;
+  let activeHeaderCell: HTMLTableCellElement | null = null;
+  let activeRow: HTMLTableRowElement | null = null;
+  let dragColFrom = -1;
+  let dragColTo = -1;
+  let isColDragging = false;
+
+  function hideAll() {
+    if (isColDragging) return;
+    addColBtn.classList.remove('visible');
+    addRowBtn.classList.remove('visible');
+    headerMenu.classList.remove('visible');
+    rowDeleteBtn.classList.remove('visible');
+    colDragHandle.classList.remove('visible');
+    activeWrapper = null;
+    activeTable = null;
+    activeHeaderCell = null;
+    activeRow = null;
+  }
+
+  const ctrlElements = [addColBtn, addRowBtn, headerMenu, rowDeleteBtn, colDragHandle];
+  function isOverTableOrControls(el: Element | null): boolean {
+    if (!el) return false;
+    if (ctrlElements.some((c) => c.contains(el))) return true;
+    return proseEl.contains(el) && !!findTableWrapper(el as Node);
+  }
+
+  document.addEventListener('mousemove', (e: MouseEvent) => {
+    if (isColDragging) return;
+    const elAt = document.elementFromPoint(e.clientX, e.clientY);
+    if (!isOverTableOrControls(elAt)) {
+      hideAll();
+      return;
+    }
+
+    const wrapper = findTableWrapper(e.target as Node);
+    const tableEl = wrapper?.querySelector('table') ?? null;
+    if (!wrapper || !tableEl) {
+      hideAll();
+      return;
+    }
+
+    const rect = wrapper.getBoundingClientRect();
+    const relX = e.clientX - rect.left;
+    const relY = e.clientY - rect.top;
+    const nearRight = relX >= rect.width - EDGE_ZONE;
+    const nearBottom = relY >= rect.height - EDGE_ZONE;
+
+    const cell = (e.target as HTMLElement).closest?.('th, td');
+    const headerCell = cell?.closest('th') ? (cell as HTMLTableCellElement) : null;
+    const row = (e.target as HTMLElement).closest?.('tr');
+    const bodyRow = row && !isHeaderRow(row) ? row : null;
+
+    if (nearRight && tableEl) {
+      activeWrapper = wrapper;
+      activeTable = tableEl;
+      addColBtn.classList.add('visible');
+      addColBtn.style.left = `${rect.right - 32}px`;
+      addColBtn.style.top = `${rect.top + rect.height / 2 - 14}px`;
+      addRowBtn.classList.remove('visible');
+      headerMenu.classList.remove('visible');
+      rowDeleteBtn.classList.remove('visible');
+      colDragHandle.classList.remove('visible');
+      return;
+    }
+
+    if (nearBottom && tableEl) {
+      activeWrapper = wrapper;
+      activeTable = tableEl;
+      addRowBtn.classList.add('visible');
+      addRowBtn.style.left = `${rect.left + rect.width / 2 - 14}px`;
+      addRowBtn.style.top = `${rect.bottom - 32}px`;
+      addColBtn.classList.remove('visible');
+      headerMenu.classList.remove('visible');
+      rowDeleteBtn.classList.remove('visible');
+      colDragHandle.classList.remove('visible');
+      return;
+    }
+
+    if (headerCell) {
+      activeWrapper = wrapper;
+      activeTable = tableEl;
+      activeHeaderCell = headerCell;
+      const hr = headerCell.getBoundingClientRect();
+      headerMenu.classList.add('visible');
+      headerMenu.style.left = `${hr.right - 90}px`;
+      headerMenu.style.top = `${hr.top + HEADER_CONTROL_OFFSET}px`;
+      addColBtn.classList.remove('visible');
+      addRowBtn.classList.remove('visible');
+      rowDeleteBtn.classList.remove('visible');
+
+      const colIdx = columnIndex(headerCell);
+      const thRect = headerCell.getBoundingClientRect();
+      colDragHandle.classList.add('visible');
+      colDragHandle.style.left = `${thRect.left - 20}px`;
+      colDragHandle.style.top = `${thRect.top + thRect.height / 2 - 8}px`;
+      colDragHandle.dataset.colIndex = String(colIdx);
+      return;
+    }
+
+    if (bodyRow) {
+      activeWrapper = wrapper;
+      activeTable = tableEl;
+      activeRow = bodyRow;
+      const rowRect = bodyRow.getBoundingClientRect();
+      rowDeleteBtn.classList.add('visible');
+      rowDeleteBtn.style.left = `${rowRect.left - 28}px`;
+      rowDeleteBtn.style.top = `${rowRect.top + rowRect.height / 2 - 10}px`;
+      addColBtn.classList.remove('visible');
+      addRowBtn.classList.remove('visible');
+      headerMenu.classList.remove('visible');
+      colDragHandle.classList.remove('visible');
+      return;
+    }
+
+    hideAll();
+  });
+
+  addColBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!activeTable) return;
+    const lastRow = activeTable.querySelector('tr');
+    const cells = lastRow?.querySelectorAll('th, td');
+    const lastCell = cells?.[cells.length - 1];
+    if (!lastCell) return;
+    const pos = getCellPos(editor, lastCell as HTMLTableCellElement);
+    editor.chain().focus().setTextSelection(pos).addColumnAfter().run();
+    hideAll();
+  });
+
+  addRowBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!activeTable) return;
+    const rows = activeTable.querySelectorAll('tr');
+    const lastRow = rows[rows.length - 1];
+    const firstCell = lastRow?.querySelector('th, td');
+    if (!firstCell) return;
+    const pos = getCellPos(editor, firstCell as HTMLTableCellElement);
+    editor.chain().focus().setTextSelection(pos).addRowAfter().run();
+    hideAll();
+  });
+
+  const sortAsc = headerMenu.querySelector('button:nth-child(1)');
+  const sortDesc = headerMenu.querySelector('button:nth-child(2)');
+  const deleteCol = headerMenu.querySelector('button:nth-child(3)');
+
+  sortAsc?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (activeTable && activeHeaderCell) {
+      sortTable(editor, activeTable, columnIndex(activeHeaderCell), true);
+    }
+    hideAll();
+  });
+
+  sortDesc?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (activeTable && activeHeaderCell) {
+      sortTable(editor, activeTable, columnIndex(activeHeaderCell), false);
+    }
+    hideAll();
+  });
+
+  deleteCol?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (activeTable && activeHeaderCell) {
+      const pos = getCellPos(editor, activeHeaderCell);
+      editor.chain().focus().setTextSelection(pos).deleteColumn().run();
+    }
+    hideAll();
+  });
+
+  rowDeleteBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!activeRow) return;
+    const firstCell = activeRow.querySelector('th, td');
+    if (!firstCell) return;
+    const pos = getCellPos(editor, firstCell as HTMLTableCellElement);
+    editor.chain().focus().setTextSelection(pos).deleteRow().run();
+    hideAll();
+  });
+
+  let dragTableRef: HTMLTableElement | null = null;
+
+  colDragHandle.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    const colIdx = parseInt(colDragHandle.dataset.colIndex ?? '-1', 10);
+    if (colIdx < 0 || !activeTable) return;
+    dragColFrom = colIdx;
+    dragColTo = colIdx;
+    dragTableRef = activeTable;
+    isColDragging = true;
+    document.addEventListener('mousemove', onColDragMove);
+    document.addEventListener('mouseup', onColDragUp);
+  });
+
+  function onColDragMove(e: MouseEvent) {
+    if (!dragTableRef) return;
+    const rows = dragTableRef.querySelectorAll('tr');
+    const firstRow = rows[0];
+    const cells = firstRow?.querySelectorAll('th, td');
+    if (!cells) return;
+    let found = -1;
+    for (let i = 0; i < cells.length; i++) {
+      const r = (cells[i] as HTMLElement).getBoundingClientRect();
+      if (e.clientX >= r.left && e.clientX <= r.right) {
+        found = i;
+        break;
+      }
+    }
+    if (found >= 0) dragColTo = found;
+  }
+
+  function onColDragUp() {
+    document.removeEventListener('mousemove', onColDragMove);
+    document.removeEventListener('mouseup', onColDragUp);
+    isColDragging = false;
+    if (dragTableRef && dragColFrom >= 0 && dragColTo >= 0 && dragColFrom !== dragColTo) {
+      moveColumn(editor, dragTableRef, dragColFrom, dragColTo);
+    }
+    dragColFrom = -1;
+    dragColTo = -1;
+    dragTableRef = null;
+    hideAll();
+  }
+}

--- a/webview-src/table-hover-ui.ts
+++ b/webview-src/table-hover-ui.ts
@@ -17,24 +17,21 @@ function findTableWrapper(el: Node | null): HTMLElement | null {
   return null;
 }
 
-function findTableEl(el: Node | null): HTMLTableElement | null {
-  while (el) {
-    if (el instanceof HTMLTableElement) return el;
-    el = el.parentElement;
+function getCellPos(editor: Editor, cell: HTMLTableCellElement): number | null {
+  try {
+    const pos = editor.view.posAtDOM(cell, 0);
+    const $pos = editor.state.doc.resolve(pos);
+    return $pos.pos + 1;
+  } catch {
+    return null;
   }
-  return null;
-}
-
-function getCellPos(editor: Editor, cell: HTMLTableCellElement): number {
-  const pos = editor.view.posAtDOM(cell, 0);
-  const $pos = editor.state.doc.resolve(pos);
-  return $pos.pos + 1;
 }
 
 function getTableNode(editor: Editor, tableEl: HTMLTableElement): { pos: number; node: ProseNode } | null {
   const cell = tableEl.querySelector('th, td');
   if (!cell) return null;
   const cellPos = getCellPos(editor, cell as HTMLTableCellElement);
+  if (cellPos == null) return null;
   const $pos = editor.state.doc.resolve(cellPos);
   for (let d = $pos.depth; d > 0; d--) {
     const node = $pos.node(d);
@@ -48,12 +45,6 @@ function columnIndex(cell: HTMLTableCellElement): number {
   if (!row) return 0;
   const cells = Array.from(row.querySelectorAll('th, td'));
   return cells.indexOf(cell);
-}
-
-function rowIndex(tr: HTMLTableRowElement): number {
-  const tbody = tr.closest('tbody, thead');
-  if (!tbody) return 0;
-  return Array.from(tbody.querySelectorAll('tr')).indexOf(tr);
 }
 
 function isHeaderRow(tr: HTMLTableRowElement): boolean {
@@ -74,6 +65,9 @@ function sortTable(editor: Editor, tableEl: HTMLTableElement, colIndex: number, 
     else bodyRows.push(row);
   });
   if (bodyRows.length <= 1) return;
+
+  const colCount = headerRows[0]?.childCount ?? bodyRows[0]?.childCount ?? 0;
+  if (colIndex >= colCount) return;
 
   const getCellText = (row: ProseNode, i: number): string => {
     const cell = row.child(i);
@@ -101,15 +95,19 @@ function moveColumn(editor: Editor, tableEl: HTMLTableElement, fromCol: number, 
   const info = getTableNode(editor, tableEl);
   if (!info || fromCol === toCol) return;
   const { pos, node } = info;
-  const schema = editor.state.schema;
+  const colCount = node.firstChild?.childCount ?? 0;
+  if (fromCol < 0 || fromCol >= colCount || toCol < 0 || toCol >= colCount) return;
+
   const newRows: ProseNode[] = [];
   node.forEach((row) => {
     const cells: ProseNode[] = [];
     row.forEach((cell) => cells.push(cell));
-    const [extracted] = cells.splice(fromCol, 1);
+    const extracted = cells.splice(fromCol, 1)[0];
+    if (!extracted) return;
     cells.splice(toCol, 0, extracted);
     newRows.push(row.type.create(row.attrs, cells));
   });
+  if (newRows.length !== node.childCount) return;
   const newTable = node.type.create(node.attrs, newRows);
   const tr = editor.state.tr.replaceWith(pos, pos + node.nodeSize, newTable);
   editor.view.dispatch(tr);
@@ -188,6 +186,7 @@ export function initTableHoverUI(editor: Editor) {
       hideAll();
       return;
     }
+    if (ctrlElements.some((c) => c.contains(elAt))) return;
 
     const wrapper = findTableWrapper(e.target as Node);
     const tableEl = wrapper?.querySelector('table') ?? null;
@@ -241,16 +240,13 @@ export function initTableHoverUI(editor: Editor) {
       headerMenu.classList.add('visible');
       headerMenu.style.left = `${hr.right - 90}px`;
       headerMenu.style.top = `${hr.top + HEADER_CONTROL_OFFSET}px`;
+      colDragHandle.classList.add('visible');
+      colDragHandle.style.left = `${hr.left - 20}px`;
+      colDragHandle.style.top = `${hr.top + hr.height / 2 - 8}px`;
+      colDragHandle.dataset.colIndex = String(columnIndex(headerCell));
       addColBtn.classList.remove('visible');
       addRowBtn.classList.remove('visible');
       rowDeleteBtn.classList.remove('visible');
-
-      const colIdx = columnIndex(headerCell);
-      const thRect = headerCell.getBoundingClientRect();
-      colDragHandle.classList.add('visible');
-      colDragHandle.style.left = `${thRect.left - 20}px`;
-      colDragHandle.style.top = `${thRect.top + thRect.height / 2 - 8}px`;
-      colDragHandle.dataset.colIndex = String(colIdx);
       return;
     }
 
@@ -279,8 +275,8 @@ export function initTableHoverUI(editor: Editor) {
     const lastRow = activeTable.querySelector('tr');
     const cells = lastRow?.querySelectorAll('th, td');
     const lastCell = cells?.[cells.length - 1];
-    if (!lastCell) return;
-    const pos = getCellPos(editor, lastCell as HTMLTableCellElement);
+    const pos = lastCell ? getCellPos(editor, lastCell as HTMLTableCellElement) : null;
+    if (pos == null) return;
     editor.chain().focus().setTextSelection(pos).addColumnAfter().run();
     hideAll();
   });
@@ -292,8 +288,8 @@ export function initTableHoverUI(editor: Editor) {
     const rows = activeTable.querySelectorAll('tr');
     const lastRow = rows[rows.length - 1];
     const firstCell = lastRow?.querySelector('th, td');
-    if (!firstCell) return;
-    const pos = getCellPos(editor, firstCell as HTMLTableCellElement);
+    const pos = firstCell ? getCellPos(editor, firstCell as HTMLTableCellElement) : null;
+    if (pos == null) return;
     editor.chain().focus().setTextSelection(pos).addRowAfter().run();
     hideAll();
   });
@@ -325,7 +321,7 @@ export function initTableHoverUI(editor: Editor) {
     e.stopPropagation();
     if (activeTable && activeHeaderCell) {
       const pos = getCellPos(editor, activeHeaderCell);
-      editor.chain().focus().setTextSelection(pos).deleteColumn().run();
+      if (pos != null) editor.chain().focus().setTextSelection(pos).deleteColumn().run();
     }
     hideAll();
   });
@@ -335,8 +331,8 @@ export function initTableHoverUI(editor: Editor) {
     e.stopPropagation();
     if (!activeRow) return;
     const firstCell = activeRow.querySelector('th, td');
-    if (!firstCell) return;
-    const pos = getCellPos(editor, firstCell as HTMLTableCellElement);
+    const pos = firstCell ? getCellPos(editor, firstCell as HTMLTableCellElement) : null;
+    if (pos == null) return;
     editor.chain().focus().setTextSelection(pos).deleteRow().run();
     hideAll();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Notion-style table editing controls so users can add and delete columns/rows, sort by column, and reorder columns directly from the UI without editing markdown source.

## Changes

### New table hover UI (`webview-src/table-hover-ui.ts`)

- **Add column**: Hover near the far right edge of a table (~24px zone) → "+" button appears → click to add a column
- **Add row**: Hover near the bottom edge → "+" button appears → click to add a row
- **Column header menu** (hover any header cell):
  - Sort ascending (↑)
  - Sort descending (↓)
  - Delete column (×)
- **Delete row**: Hover any body row → "×" button appears on the left → click to delete the row
- **Reorder columns**: Drag handle (⋮⋮) appears when hovering a column header; drag to reorder

### Sort behavior

- Sorts body rows only (header row stays fixed)
- Tries numeric comparison when cell content looks like numbers
- Falls back to lexicographic sort for text

### Column reorder

- Uses a custom ProseMirror transaction to move column data across all rows

### Code quality (review pass)

- Removed unused helpers (`findTableEl`, `rowIndex`, `schema`)
- Fixed bug: controls now stay visible when hovering buttons (no longer disappear before click)
- `getCellPos` returns `null` on error, with try/catch for stale DOM; all call sites handle `null`
- Bounds checks for `sortTable` (colIndex) and `moveColumn` (fromCol/toCol)
- Guard against corrupt move when `extracted` is missing
- Deduplicated `getBoundingClientRect` in header cell block

### Other

- Table controls are hidden when printing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64b6de1d-3ea3-41a0-b3a6-73b8e1d26716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64b6de1d-3ea3-41a0-b3a6-73b8e1d26716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

